### PR TITLE
Option for reporting details of pending specs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,7 +56,7 @@ module.exports = function (grunt) {
 				options: {
 					base_path: 'test/'
 				},
-				src: ['test/async_slow.test.ts', 'test/objectDiff.test.ts', 'test/jsDiff.test.ts'],
+				src: ['test/async_slow.test.ts', 'test/objectDiff.test.ts', 'test/jsDiff.test.ts', 'test/pending.test.ts'],
 				dest: 'test/_tmp.test.js'
 			},
 			test_objectDiff: {
@@ -160,8 +160,9 @@ module.exports = function (grunt) {
 	//process.env['mocha-unfunk-style'] = 'plain';
 	//process.env['mocha-unfunk-writer'] = 'log';
 	//require('mocha-unfunk-reporter').option({style:'ansi', writer:'stdout'});
+	process.env['mocha-unfunk-reportPending'] = true;
 
-	grunt.registerTask('default', ['test']);
+    grunt.registerTask('default', ['test']);
 
 	grunt.registerTask('test', ['build_pass', 'run_core']);
 	grunt.registerTask('run_core', ['mochaTest', 'mocha']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,7 +162,7 @@ module.exports = function (grunt) {
 	//require('mocha-unfunk-reporter').option({style:'ansi', writer:'stdout'});
 	process.env['mocha-unfunk-reportPending'] = true;
 
-    grunt.registerTask('default', ['test']);
+	grunt.registerTask('default', ['test']);
 
 	grunt.registerTask('test', ['build_pass', 'run_core']);
 	grunt.registerTask('run_core', ['mochaTest', 'mocha']);

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Output mode: `writer`
 * `'bulk'` - single buffered `console.log()`
 * `'null'` - ignore output
 
+Report details about pending specs, alongside failures: `reportPending`
+
+* `false` (default) or `true`
+
 Use custom stream: `stream` 
 
 * any standard `WritableStream`

--- a/build/unfunk.js
+++ b/build/unfunk.js
@@ -1083,10 +1083,10 @@ var unfunk;
                 } else {
                     sum += style.warning(pluralize('test', stats.tests));
                 }
-                if(stats.pending > 0) {
+                if(pending.length > 0) {
                     sum += ', left ' + style.warning(stats.pending + ' pending');
                 }
-                if(options.reportPending && stats.pending > 0) {
+                if(options.reportPending && pending.length > 0) {
                     out.writeln(style.accent('->') + ' reporting ' + style.warn(pluralize('pending spec', pending.length)));
                     out.writeln();
                     pending.forEach(function (test, num) {

--- a/build/unfunk.js
+++ b/build/unfunk.js
@@ -977,6 +977,7 @@ var unfunk;
             var indents = 0;
             var indenter = '   ';
             var failures = this.failures = [];
+            var pending = this.pending = [];
             var suiteStack = [];
             var currentSuite;
             var indent = function (add) {
@@ -1034,6 +1035,7 @@ var unfunk;
             runner.on('pending', function (test) {
                 stats.pending++;
                 out.writeln(indent(0) + style.main(test.title + '.. ') + style.warn('pending'));
+                pending.push(test);
             });
             runner.on('pass', function (test) {
                 stats.passes++;
@@ -1083,6 +1085,17 @@ var unfunk;
                 }
                 if(stats.pending > 0) {
                     sum += ', left ' + style.warning(stats.pending + ' pending');
+                }
+                if(options.reportPending && stats.pending > 0) {
+                    out.writeln(style.accent('->') + ' reporting ' + style.warn(pluralize('pending spec', pending.length)));
+                    out.writeln();
+                    pending.forEach(function (test, num) {
+                        var tmp = test.fullTitle();
+                        var ind = tmp.lastIndexOf(test.title);
+                        var title = style.accent(tmp.substring(0, ind)) + style.main(tmp.substring(ind));
+                        out.writeln(style.warn(padRight((num + 1) + ': ', indentLen(2), ' ')) + title);
+                    });
+                    out.writeln();
                 }
                 if(failures.length > 0) {
                     out.writeln(style.accent('->') + ' reporting ' + style.error(pluralize('failure', failures.length)));

--- a/src/unfunk.ts
+++ b/src/unfunk.ts
@@ -221,7 +221,7 @@ module unfunk {
 
 		stats:Stats;
 		failures:Test[];
-        pending:Test[];
+		pending:Test[];
         
 		constructor(runner) {
 			this.init(runner);
@@ -354,7 +354,7 @@ module unfunk {
 			runner.on('pending', (test:Test) => {
 				stats.pending++;
 				out.writeln(indent(0) + style.main(test.title + '.. ') + style.warn('pending'));
-                pending.push(test);
+				pending.push(test);
             });
 
 			runner.on('pass', (test:Test) => {
@@ -417,22 +417,22 @@ module unfunk {
 						sum += style.warning(pluralize('test', stats.tests));
 					}
 
-					if (stats.pending > 0) {
+					if (pending.length > 0) {
 						sum += ', left ' + style.warning(stats.pending + ' pending');
 					}
 
 					//details
-                    if(options.reportPending && stats.pending > 0) {
-                        out.writeln(style.accent('->') + ' reporting ' + style.warn(pluralize('pending spec', pending.length)));
+					if(options.reportPending && pending.length > 0) {
+						out.writeln(style.accent('->') + ' reporting ' + style.warn(pluralize('pending spec', pending.length)));
+						out.writeln();
+						pending.forEach((test:Test, num:number) => {
+							var tmp = test.fullTitle();
+							var ind = tmp.lastIndexOf(test.title);
+							var title = style.accent(tmp.substring(0, ind)) + style.main(tmp.substring(ind));
+							out.writeln(style.warn(padRight((num + 1) + ': ', indentLen(2), ' ')) + title);
+						});
                         out.writeln();
-                        pending.forEach(function (test, num) {
-                            var tmp = test.fullTitle();
-                            var ind = tmp.lastIndexOf(test.title);
-                            var title = style.accent(tmp.substring(0, ind)) + style.main(tmp.substring(ind));
-                            out.writeln(style.warn(padRight((num + 1) + ': ', indentLen(2), ' ')) + title);
-                        });
-                        out.writeln();
-                    }                        
+					}                        
 					if (failures.length > 0) {
 
 						out.writeln(style.accent('->') + ' reporting ' + style.error(pluralize('failure', failures.length)));

--- a/src/unfunk.ts
+++ b/src/unfunk.ts
@@ -431,7 +431,7 @@ module unfunk {
 							var title = style.accent(tmp.substring(0, ind)) + style.main(tmp.substring(ind));
 							out.writeln(style.warn(padRight((num + 1) + ': ', indentLen(2), ' ')) + title);
 						});
-                        out.writeln();
+						out.writeln();
 					}                        
 					if (failures.length > 0) {
 

--- a/src/unfunk.ts
+++ b/src/unfunk.ts
@@ -221,7 +221,8 @@ module unfunk {
 
 		stats:Stats;
 		failures:Test[];
-
+        pending:Test[];
+        
 		constructor(runner) {
 			this.init(runner);
 		}
@@ -289,7 +290,8 @@ module unfunk {
 			var indents = 0;
 			var indenter:string = '   ';
 			var failures = this.failures = [];
-			var suiteStack:TestSuite[] = [];
+            var pending = this.pending = [];
+            var suiteStack:TestSuite[] = [];
 			var currentSuite:TestSuite;
 
 			var indent = (add?:number = 0):string => {
@@ -352,7 +354,8 @@ module unfunk {
 			runner.on('pending', (test:Test) => {
 				stats.pending++;
 				out.writeln(indent(0) + style.main(test.title + '.. ') + style.warn('pending'));
-			});
+                pending.push(test);
+            });
 
 			runner.on('pass', (test:Test) => {
 				stats.passes++;
@@ -419,6 +422,17 @@ module unfunk {
 					}
 
 					//details
+                    if(options.reportPending && stats.pending > 0) {
+                        out.writeln(style.accent('->') + ' reporting ' + style.warn(pluralize('pending spec', pending.length)));
+                        out.writeln();
+                        pending.forEach(function (test, num) {
+                            var tmp = test.fullTitle();
+                            var ind = tmp.lastIndexOf(test.title);
+                            var title = style.accent(tmp.substring(0, ind)) + style.main(tmp.substring(ind));
+                            out.writeln(style.warn(padRight((num + 1) + ': ', indentLen(2), ' ')) + title);
+                        });
+                        out.writeln();
+                    }                        
 					if (failures.length > 0) {
 
 						out.writeln(style.accent('->') + ' reporting ' + style.error(pluralize('failure', failures.length)));

--- a/test/pending.test.ts
+++ b/test/pending.test.ts
@@ -1,0 +1,27 @@
+///<reference path="_ref.ts" />
+
+declare var assert:chai.Assert;
+
+describe('pending specs', () => {
+	it.skip('this is the first pending spec', (done:() => void) => {
+		setTimeout(() => {
+			assert.ok(true);
+			done();
+		}, 10);
+	});
+
+    it.skip('and a second pending spec', (done:() => void) => {
+        setTimeout(() => {
+            assert.ok(true);
+            done();
+        }, 10);
+    });
+
+    it.skip('finally a third pending spec', (done:() => void) => {
+        setTimeout(() => {
+            assert.ok(true);
+            done();
+        }, 10);
+    });
+});
+


### PR DESCRIPTION
This is useful when there are a very large number of specs, and you want to easily identify any "technical debt" specs that have not yet been implemented, without having to scroll through a large report and find them individually.
